### PR TITLE
Default to synchronous consensus mode.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         php: [7.4]
         laravel: [7.*]
-        dependency-version: [prefer-lowest, prefer-stable]
+        dependency-version: [prefer-stable]
         include:
           - laravel: 7.*
             testbench: 5.*

--- a/src/Http/Controllers/LaravelHashgraphWebhookController.php
+++ b/src/Http/Controllers/LaravelHashgraphWebhookController.php
@@ -16,7 +16,7 @@ class LaravelHashgraphWebhookController extends Controller
     {
         // Check that the signature exists
         $signature = $request->header('x-signature');
-        abort_unless($signature, Response::HTTP_BAD_REQUEST, 'Header X-Signature is required');
+        abort_unless(! ! $signature, Response::HTTP_BAD_REQUEST, 'Header X-Signature is required');
 
         // Check the signature is valid
         $hash = Hmac::generate($request->getContent());

--- a/src/Models/ConsensusMessage.php
+++ b/src/Models/ConsensusMessage.php
@@ -11,7 +11,17 @@ class ConsensusMessage
 
     private ?string $reference = null;
 
-    private bool $allow_synchronous_consensus = false;
+    /*
+     * Synchronous consensus defaults to true as the
+     * default serverless provider is Vercel and by
+     * extension AWS Lambda. Async consensus us incompatible
+     * in this current version, due to a serverless container
+     * sleeping directly after a HTTP response is sent.
+     *
+     * With Laravel recommend that all Hashgraph usage is
+     * executed through a Job.
+     */
+    private bool $allow_synchronous_consensus = true;
 
     /**
      * ConsensusMessage constructor.
@@ -29,12 +39,9 @@ class ConsensusMessage
             'topic_id' => $this->getTopicId(),
         ];
 
-        $allow_synchronous = $this->isAllowSynchronousConsensus();
         $reference = $this->getReference();
 
-        if ($allow_synchronous) {
-            $message_payload['allow_synchronous_consensus'] = true;
-        }
+        $message_payload['allow_synchronous_consensus'] = $this->getReference();
 
         if ($reference) {
             $message_payload['reference'] = $reference;

--- a/src/Models/ConsensusMessage.php
+++ b/src/Models/ConsensusMessage.php
@@ -41,7 +41,7 @@ class ConsensusMessage
 
         $reference = $this->getReference();
 
-        $message_payload['allow_synchronous_consensus'] = $this->getReference();
+        $message_payload['allow_synchronous_consensus'] = $this->isAllowSynchronousConsensus();
 
         if ($reference) {
             $message_payload['reference'] = $reference;

--- a/src/Models/TopicInfo.php
+++ b/src/Models/TopicInfo.php
@@ -4,7 +4,7 @@ namespace Trustenterprises\LaravelHashgraph\Models;
 
 class TopicInfo
 {
-    const EMPTY_TOPIC_ID = -1;
+    const EMPTY_TOPIC_ID = "-1";
 
     private String $memo;
 

--- a/tests/LaravelHashgraphTest.php
+++ b/tests/LaravelHashgraphTest.php
@@ -93,7 +93,7 @@ class LaravelHashgraphTest extends TestCase
 
         $this->assertEquals($topic->topic_id, $message_response->getTopicId());
         $this->assertNull($message_response->getReference());
-        $this->assertNull($message_response->getConsensusTimestamp());
+        $this->assertNotNull($message_response->getConsensusTimestamp());
 
         // This tests the response of a synchronous message
         $reference = 'laravel-hashgraph-test';


### PR DESCRIPTION
## Rationale

Ensure that the request is synchronous, to keep the connection open or the NodeJS event loop deployed as a serverless app.