### PR TITLE
Bump guzzle for Laravel 8 default installation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": "^7.4",
-        "guzzlehttp/guzzle": "^6.0",
+        "guzzlehttp/guzzle": "^7.0",
         "ext-json": "*"
     },
     "require-dev": {


### PR DESCRIPTION
We'll provide lower guzzle capability for Laravel 5.8.* as a different release.